### PR TITLE
Fix metastring parameters propagation to CodeBlock

### DIFF
--- a/src/theme/ReferenceCodeBlock/index.tsx
+++ b/src/theme/ReferenceCodeBlock/index.tsx
@@ -31,8 +31,8 @@ function ReferenceCode(props: ReferenceCodeBlockProps) {
     const customProps = {
         ...props,
         metastring: titleMatch?.groups?.title
-            ? ` title="${titleMatch?.groups?.title}"`
-            : ` title="${codeSnippetDetails.title}"`,
+            ? `${props.metastring} title="${titleMatch?.groups?.title}"`
+            : `${props.metastring} title="${codeSnippetDetails.title}"`,
         children: initialFetchResultState.code,
     };
 


### PR DESCRIPTION
Fixed ability to setup CodeBlock parameters like [Line numbering](https://docusaurus.io/docs/markdown-features/code-blocks#line-numbering) or [Highlighting](https://docusaurus.io/docs/markdown-features/code-blocks#highlighting-with-metadata-string)